### PR TITLE
refocus inside didInsertElement, instead of every didRender

### DIFF
--- a/addon/components/focus-trapper.js
+++ b/addon/components/focus-trapper.js
@@ -20,11 +20,16 @@ const FOCUSABLE = [
 export default Component.extend({
   layout,
 
-  didRender() {
+  didInsertElement() {
     // run this on every render in case the html contents change
     this.set('allFocusableEl', this.get('element').querySelectorAll(FOCUSABLE.join(', ')));
     // move focus into the focus-trapper if focus is outside the trapper
     this.get('refocus').bind(this)();
+  },
+
+  didRender() {
+    // run this on every render in case the html contents change
+    this.set('allFocusableEl', this.get('element').querySelectorAll(FOCUSABLE.join(', ')));
   },
 
   firstFocusableEl: computed('allFocusableEl', function() {


### PR DESCRIPTION
There was a bug uncovered in real-world usage where it was possible for focus to be briefly moved to the body during the didRender phase (eg other component within the focus trapper were managing focus), which would trigger a refocus of the first focusable element. This was generally undesirable behavior.

The purpose of the `refocus` in didRender was really to move focus into the focus trapper on the initial render, doing this in didRender is, in hind sight, too aggressive. 

This PR adds a didInsertElement hook which now runs `refocus` and also sets `allFocusableEl` since that must occur before `refocus`.